### PR TITLE
.length()/.point() for lengthless paths.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.0.0
+version = 1.1.1
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md
@@ -10,7 +10,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: PyPy

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -4599,7 +4599,10 @@ class Path(Shape, MutableSequence):
             return
         lengths = [each.length(error=error, min_depth=min_depth) for each in self._segments]
         self._length = sum(lengths)
-        self._lengths = [each / self._length for each in lengths]
+        if self._length == 0:
+            self._lengths = lengths
+        else:
+            self._lengths = [each / self._length for each in lengths]
 
     def point(self, position, error=ERROR):
         if len(self._segments) == 0:
@@ -4611,6 +4614,10 @@ class Path(Shape, MutableSequence):
             return self._segments[-1].point(position)
 
         self._calc_lengths(error=error)
+
+        if self._length == 0:
+            i = int(round(position * (len(self._segments) - 1)))
+            return self._segments[i].point(0.0)
         # Find which segment the point we search for is located on:
         segment_start = 0
         segment_pos = 0

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -200,3 +200,23 @@ class TestParser(unittest.TestCase):
         for e in svg.elements():
             if isinstance(e, Path):
                 self.assertEqual(e, "M0,0 L1,0 z")
+
+    def test_solo_move(self):
+        move_only = Path("M0,0")
+        self.assertEqual(move_only.point(0), 0 + 0j)
+        self.assertEqual(move_only.point(0.5), 0 + 0j)
+        self.assertEqual(move_only.point(1), 0 + 0j)
+        self.assertEqual(move_only.length(), 0)
+
+        move_onlyz = Path("M0,0Z")
+        self.assertEqual(move_onlyz.point(0), 0 + 0j)
+        self.assertEqual(move_onlyz.point(0.5), 0 + 0j)
+        self.assertEqual(move_onlyz.point(1), 0 + 0j)
+        self.assertEqual(move_onlyz.length(), 0)
+
+        move_2_places = Path("M0,0M1,1")
+        self.assertEqual(move_2_places.point(0), 0 + 0j)
+        self.assertEqual(move_2_places.point(0.49), 0 + 0j)
+        self.assertEqual(move_2_places.point(0.51), 1 + 1j)
+        self.assertEqual(move_2_places.point(1), 1 + 1j)
+        self.assertEqual(move_2_places.length(), 0)


### PR DESCRIPTION
Corrects and adds a test for length and point for lengthless paths.