### PR TITLE
Fixed a crash with str() on incomplete viewbox

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -870,6 +870,8 @@ class Length(object):
 
     @staticmethod
     def str(s):
+        if s is None:
+            return "n/a"
         if isinstance(s, Length):
             if s.units == '':
                 s = s.amount

--- a/test/test_viewbox.py
+++ b/test/test_viewbox.py
@@ -32,3 +32,10 @@ class TestElementViewbox(unittest.TestCase):
     def test_viewbox_translate(self):
         v = Viewbox({'viewBox': '-50 -50 100 100', 'height': 100, 'width': 100})
         self.assertEqual(v.transform(), 'translate(50, 50)')
+
+    def test_viewbox_incomplete_print(self):
+        v = Viewbox({'viewBox': None, 'height': 200, 'width': 200})
+        try:
+            str(v)
+        except TypeError:
+            self.fail("str(viewbox) should not fail for incomplete viewbox")


### PR DESCRIPTION
Here is a small fix for a crash that threw me off with my early experiences with `svgelements`.