### PR TITLE
Optimize CubicBezier.length() with scipy if available

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3672,9 +3672,30 @@ class CubicBezier(PathSegment):
         local_extrema = [self.point(t)[v] for t in local_extremizers]
         return min(local_extrema), max(local_extrema)
 
+    def _derivative(self, t):
+        """returns the nth derivative of the segment at t.
+        Note: Bezier curves can have points where their derivative vanishes.
+        If you are interested in the tangent direction, use the unit_tangent()
+        method instead."""
+        p = [self.start, self.control1, self.control2, self.end]
+        return 3 * (p[1] - p[0]) * (1 - t) ** 2 + 6 * (p[2] - p[1]) * (
+                    1 - t) * t + 3 * (
+                           p[3] - p[2]) * t ** 2
+
+    def _length_scipy(self, error=ERROR):
+        from scipy.integrate import quad
+        return quad(lambda tau: abs(self._derivative(tau)), 0., 1.,
+                    epsabs=error, limit=1000)[0]
+
+    def _length_default(self, error=ERROR, min_depth=MIN_DEPTH):
+        return self._line_length(0, 1, error, min_depth)
+
     def length(self, error=ERROR, min_depth=MIN_DEPTH):
         """Calculate the length of the path up to a certain position"""
-        return self._line_length(0, 1, error, min_depth)
+        try:
+            return self._length_scipy(error)
+        except ModuleNotFoundError:
+            return self._length_default(error, min_depth)
 
     def is_smooth_from(self, previous):
         """Checks if this segment would be a smooth segment following the previous"""

--- a/test/test_cubic_bezier_length.py
+++ b/test/test_cubic_bezier_length.py
@@ -1,0 +1,21 @@
+from __future__ import print_function
+
+import unittest
+from random import *
+
+from svgelements import *
+
+
+def get_random_cubic_bezier():
+    return CubicBezier((random() * 50, random() * 50), (random() * 50, random() * 50),
+                       (random() * 50, random() * 50), (random() * 50, random() * 50))
+
+
+class TestElementCubicBezierLength(unittest.TestCase):
+
+    def test_cubic_bezier_length(self):
+        for _ in range(100):
+            b = get_random_cubic_bezier()
+            l1 = b._length_scipy()
+            l2 = b._length_default()
+            self.assertAlmostEqual(l1, l2)


### PR DESCRIPTION
A new scipy-based implementation of `CubicBezier.length()` is added and used if scipy is available. A new test checks that the result of the scipy and default implementation match.

Simple benchmark:

```
In [4]: p = svgelements.CubicBezier((3, 4), (324, 12), (32, 234), (123, 456))

In [5]: %timeit p._length_default()
1.44 s ± 5.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %timeit p._length_scipy()
2.5 ms ± 143 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Due to how slow the current implementation is, this test currently increase execution time by more than a 1 minute on my computer. Should I reduce the number of iteration?

Fixes #55 