### PR TITLE
1.2.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.2.9
+version = 1.2.10
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -28,7 +28,7 @@ Though not required the SVGImage class acquires new functionality if provided wi
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.2.9"
+SVGELEMENTS_VERSION = "1.2.10"
 
 MIN_DEPTH = 5
 ERROR = 1e-12
@@ -882,7 +882,10 @@ class Length(object):
                 if '.' in a:
                     a = a.rstrip('0').rstrip('.')
                 return '\'%s%s\'' % (a, s.units)
-        s = '%.12f' % (s)
+        try:
+            s = '%.12f' % (s)
+        except TypeError:
+            return str(s)
         if '.' in s:
             s = s.rstrip('0').rstrip('.')
         return s


### PR DESCRIPTION
Correct Crash for Length.str() which fixes np.array() calls to most of the point() routines.