### PR TITLE
Make Point compatible with numpy.array()

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -1763,6 +1763,9 @@ class Point:
     def __ne__(self, other):
         return not self == other
 
+    def __len__(self):
+        return 2
+
     def __getitem__(self, item):
         if item == 0:
             return self.x


### PR DESCRIPTION
This tiny fix makes `Point` compatible with numpy:

```python
>>> np.array([Point(1, 2), Point(3, 4), Point(5, 6)])
array([[1, 2],
       [3, 4],
       [5, 6]])
```

This is greatly useful to convert Polygon/Polyline's `points` to numpy array:

```python
# this works and does what you think it should
poly = Polyline(points=((10, 20), (30, 20), (100, 200), (32, 64)))
pts = np.array(poly.points)
```