### PR TITLE
Setting Fill-Opacity on Fill=None

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.4.0
+version = 1.4.1
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -28,7 +28,7 @@ Though not required the SVGImage class acquires new functionality if provided wi
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.4.0"
+SVGELEMENTS_VERSION = "1.4.1"
 
 MIN_DEPTH = 5
 ERROR = 1e-12
@@ -3054,7 +3054,7 @@ class GraphicObject:
         stroke = values.get(SVG_ATTR_STROKE)
         self.stroke = Color(stroke) if stroke is not None else None
         stroke_opacity = values.get(SVG_ATTR_STROKE_OPACITY)
-        if stroke_opacity is not None and self.stroke is not None:
+        if stroke_opacity is not None and self.stroke is not None and self.stroke.value is not None:
             try:
                 self.stroke.opacity = float(stroke_opacity)
             except ValueError:
@@ -3062,7 +3062,7 @@ class GraphicObject:
         fill = values.get(SVG_ATTR_FILL)
         self.fill = Color(fill) if fill is not None else None
         fill_opacity = values.get(SVG_ATTR_FILL_OPACITY)
-        if fill_opacity is not None and self.fill is not None:
+        if fill_opacity is not None and self.fill is not None and self.fill.value is not None:
             try:
                 self.fill.opacity = float(fill_opacity)
             except ValueError:

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -225,6 +225,14 @@ class TestParser(unittest.TestCase):
         self.assertEqual(move_2_places.point(1), 1 + 1j)
         self.assertEqual(move_2_places.length(), 0)
 
+    def test_fill_opacity_fill_none(self):
+        s = io.StringIO('<svg><path d="M0,0 H10 V10 H0 z" fill-opacity="1" fill="none" /></svg>')
+        svg = SVG.parse(s)
+        for e in svg.elements():
+            if isinstance(e, Path):
+                self.assertEqual(e, "M0,0 H10 V10 H0 z")
+                self.assertEqual(e.fill, "none" )
+
 
 class TestParseDisplay(unittest.TestCase):
     """


### PR DESCRIPTION
Introduced a small bug. If fill-opacity is set on a fill=none, it crashes.