### PR TITLE
1.4.8

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -6184,8 +6184,6 @@ class Rect(Shape):
 
         Skewed and Rotated rectangles cannot be reified.
         """
-        GraphicObject.reify(self)
-        Transformable.reify(self)
         scale_x = self.transform.value_scale_x()
         scale_y = self.transform.value_scale_y()
         translate_x = self.transform.value_trans_x()
@@ -6196,6 +6194,8 @@ class Rect(Shape):
             and scale_x != 0
             and scale_y != 0
         ):
+            GraphicObject.reify(self)
+            Transformable.reify(self)
             self.x *= scale_x
             self.y *= scale_y
             self.x += translate_x
@@ -6384,8 +6384,6 @@ class _RoundShape(Shape):
 
         Skewed and Rotated roundshapes cannot be reified.
         """
-        GraphicObject.reify(self)
-        Transformable.reify(self)
         scale_x = abs(self.transform.value_scale_x())
         scale_y = abs(self.transform.value_scale_y())
         translate_x = self.transform.value_trans_x()
@@ -6396,6 +6394,8 @@ class _RoundShape(Shape):
             and scale_x != 0
             and scale_y != 0
         ):
+            GraphicObject.reify(self)
+            Transformable.reify(self)
             self.cx *= scale_x
             self.cy *= scale_y
             self.cx += translate_x

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import unittest
+import io
 
 from svgelements import *
 
@@ -402,6 +403,25 @@ class TestElementShape(unittest.TestCase):
         self.assertEqual(Circle(0, 0, 0).d(), '')
         self.assertEqual(Ellipse(0,0,0,100).d(), '')
         self.assertEqual(Ellipse(0, 0, 100, 0).d(), '')
+
+    def test_issue_95(self):
+        """Testing Issue 95 stroke-width"""
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg>
+                        <ellipse style="stroke:#fc0000;stroke-width:1;fill:none" cx="0" cy="0" rx="1" ry="1" transform="scale(100) rotate(-90,0,0)"/>
+                        <rect style="stroke:#fc0000;stroke-width:1;fill:none" x="0" y="0" width="10" height="10" transform="scale(100) rotate(-90,0,0)"/>
+                        </svg>''')
+        m = SVG.parse(q)
+        ellipse = m[0]
+        for i in range(5):
+            ellipse = ellipse.reify()
+        self.assertEqual(ellipse.stroke_width, 1.0)
+
+        rect = m[1]
+        for i in range(5):
+            rect = rect.reify()
+        self.assertEqual(rect.stroke_width, 1.0)
+
 
     def test_shape_npoints(self):
         import numpy as np


### PR DESCRIPTION
* Corrects Issue 95. Multiple Reification of Stroke-Width for Skewed Matrices.
* Gives `Group` a static function for bbox.
* `Color` now can use long and correct for it rather than cheating and keeping shorts.
* `Color` accepts String of integer.