### PR TITLE
Improve __repr__ and Viewbox

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3030,17 +3030,18 @@ class Matrix:
 
 
 class Viewbox:
-    def __init__(self, *args, x=None, y=None, width=None, height=None, preserveAspectRatio=None, preserve_aspect_ratio=None):
+    def __init__(self, *args, **kwargs):
         """
         Viewbox controls the scaling between the drawing size view that is observing that drawing.
 
         :param viewbox: either values or viewbox attribute or a Viewbox object
         :param preserveAspectRatio or preserve_aspect_ratio: preserveAspectRatio
         """
-        self.x = x
-        self.y = y
-        self.width = width
-        self.height = height
+        self.x = None
+        self.y = None
+        self.width = None
+        self.height = None
+        self.preserve_aspect_ratio = None
         if args and len(args) <= 2:
             viewbox = args[0]
             if isinstance(viewbox, dict):
@@ -3050,18 +3051,14 @@ class Viewbox:
             else:
                 self.set_viewbox(viewbox)
             if len(args) == 2:
-                preserveAspectRatio = args[1]
+                self.preserve_aspect_ratio = args[1]
         elif len(args) == 4:
             self.x = float(args[0])
             self.y = float(args[1])
             self.width = float(args[2])
             self.height = float(args[3])
-        if preserveAspectRatio != SVG_VALUE_NONE:
-            self.preserve_aspect_ratio = preserveAspectRatio
-        elif preserve_aspect_ratio != SVG_VALUE_NONE:
-            self.preserve_aspect_ratio = preserve_aspect_ratio
         else:
-            self.preserve_aspect_ratio = None
+            self.property_by_values(dict(kwargs))
 
     def __eq__(self, other):
         if not isinstance(other, Viewbox):
@@ -3095,7 +3092,7 @@ class Viewbox:
         if self.height is not None:
             values.append("height=%s" % Length.str(self.height))
         if self.preserve_aspect_ratio is not None:
-            values.append("%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserve_aspect_ratio))
+            values.append("%s='%s'" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserve_aspect_ratio))
         params = ", ".join(values)
         return "Viewbox(%s)" % params
 
@@ -3107,9 +3104,8 @@ class Viewbox:
         self.preserve_aspect_ratio = obj.preserve_aspect_ratio
 
     def property_by_values(self, values):
-        viewbox = values.get(SVG_ATTR_VIEWBOX)
-        if viewbox is not None:
-            self.set_viewbox(viewbox)
+        if SVG_ATTR_VIEWBOX in values:
+            self.set_viewbox(values[SVG_ATTR_VIEWBOX])
         if SVG_ATTR_X in values:
             self.x = values[SVG_ATTR_X]
         if SVG_ATTR_Y in values:
@@ -3118,6 +3114,8 @@ class Viewbox:
             self.width = values[SVG_ATTR_WIDTH]
         if SVG_ATTR_HEIGHT in values:
             self.height = values[SVG_ATTR_HEIGHT]
+        if "preserve_aspect_ratio" in values:
+            self.preserve_aspect_ratio = values["preserve_aspect_ratio"]
         if SVG_ATTR_PRESERVEASPECTRATIO in values:
             self.preserve_aspect_ratio = values[SVG_ATTR_PRESERVEASPECTRATIO]
 

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3092,7 +3092,6 @@ class Viewbox:
             values.append("width=%s" % Length.str(self.width))
         if self.height is not None:
             values.append("height=%s" % Length.str(self.height))
-        print("__repr__",self.preserveAspectRatio)
         if self.preserveAspectRatio is not None:
             values.append("%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserveAspectRatio))
         params = ", ".join(values)

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3030,12 +3030,12 @@ class Matrix:
 
 
 class Viewbox:
-    def __init__(self, *args, x=None, y=None, width=None, height=None, preserve_aspect_ratio=None):
+    def __init__(self, *args, x=None, y=None, width=None, height=None, preserveAspectRatio=None):
         """
         Viewbox controls the scaling between the drawing size view that is observing that drawing.
 
         :param viewbox: either values or viewbox attribute or a Viewbox object
-        :param preserve_aspect_ratio: preserveAspectRatio
+        :param preserveAspectRatio: preserveAspectRatio
         """
         self.x = x
         self.y = y
@@ -3050,16 +3050,16 @@ class Viewbox:
             else:
                 self.set_viewbox(viewbox)
             if len(args) == 2:
-                preserve_aspect_ratio == args[1]
+                preserveAspectRatio = args[1]
         elif len(args) == 4:
             self.x = float(args[0])
             self.y = float(args[1])
             self.width = float(args[2])
             self.height = float(args[3])
-        if preserve_aspect_ratio == SVG_VALUE_NONE:
-            self.preserve_aspect_ratio = None
+        if preserveAspectRatio == SVG_VALUE_NONE:
+            self.preserveAspectRatio = None
         else:
-            self.preserve_aspect_ratio = preserve_aspect_ratio
+            self.preserveAspectRatio = preserveAspectRatio
 
     def __eq__(self, other):
         if not isinstance(other, Viewbox):
@@ -3072,7 +3072,7 @@ class Viewbox:
             return False
         if self.height != other.height:
             return False
-        return self.preserve_aspect_ratio == other.preserve_aspect_ratio
+        return self.preserveAspectRatio == other.preserveAspectRatio
 
     def __str__(self):
         return "%s %s %s %s" % (
@@ -3092,8 +3092,9 @@ class Viewbox:
             values.append("width=%s" % Length.str(self.width))
         if self.height is not None:
             values.append("height=%s" % Length.str(self.height))
-        if self.preserve_aspect_ratio is not None:
-            values.append("%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserve_aspect_ratio))
+        print("__repr__",self.preserveAspectRatio)
+        if self.preserveAspectRatio is not None:
+            values.append("%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserveAspectRatio))
         params = ", ".join(values)
         return "Viewbox(%s)" % params
 
@@ -3102,14 +3103,14 @@ class Viewbox:
         self.y = obj.y
         self.width = obj.width
         self.height = obj.height
-        self.preserve_aspect_ratio = obj.preserve_aspect_ratio
+        self.preserveAspectRatio = obj.preserveAspectRatio
 
     def property_by_values(self, values):
         viewbox = values.get(SVG_ATTR_VIEWBOX)
         if viewbox is not None:
             self.set_viewbox(viewbox)
         if SVG_ATTR_PRESERVEASPECTRATIO in values:
-            self.preserve_aspect_ratio = values[SVG_ATTR_PRESERVEASPECTRATIO]
+            self.preserveAspectRatio = values[SVG_ATTR_PRESERVEASPECTRATIO]
 
     def set_viewbox(self, viewbox):
         if viewbox is not None:
@@ -3132,7 +3133,7 @@ class Viewbox:
             self.y,
             self.width,
             self.height,
-            self.preserve_aspect_ratio,
+            self.preserveAspectRatio,
         )
 
     @staticmethod
@@ -7416,7 +7417,7 @@ class ClipPath(SVGElement, list):
 class Pattern(SVGElement, list):
     def __init__(self, *args, **kwargs):
         self.viewbox = None
-        self.preserve_aspect_ratio = None
+        self.preserveAspectRatio = None
         self.x = None
         self.y = None
         self.width = None
@@ -7439,7 +7440,7 @@ class Pattern(SVGElement, list):
     def property_by_object(self, s):
         SVGElement.property_by_object(self, s)
         self.viewbox = s.viewbox
-        self.preserve_aspect_ratio = s.preserve_aspect_ratio
+        self.preserveAspectRatio = s.preserveAspectRatio
 
         self.x = s.x
         self.y = s.y
@@ -7462,7 +7463,7 @@ class Pattern(SVGElement, list):
         if viewbox is not None:
             self.viewbox = Viewbox(viewbox)
         if SVG_ATTR_PRESERVEASPECTRATIO in values:
-            self.preserve_aspect_ratio = values[SVG_ATTR_PRESERVEASPECTRATIO]
+            self.preserveAspectRatio = values[SVG_ATTR_PRESERVEASPECTRATIO]
         self.x = Length(values.get(SVG_ATTR_X, 0)).value()
         self.y = Length(values.get(SVG_ATTR_Y, 0)).value()
         self.width = Length(values.get(SVG_ATTR_WIDTH, "100%")).value()
@@ -7696,7 +7697,7 @@ class SVGImage(SVGElement, GraphicObject, Transformable):
         self.url = None
         self.data = None
         self.viewbox = None
-        self.preserve_aspect_ratio = None
+        self.preserveAspectRatio = None
         self.x = None
         self.y = None
         self.width = None
@@ -7739,9 +7740,9 @@ class SVGImage(SVGElement, GraphicObject, Transformable):
             values.append("image_width=%s" % Length.str(self.image_width))
         if self.image_height != 0:
             values.append("image_height=%s" % Length.str(self.image_height))
-        if self.preserve_aspect_ratio is not None:
+        if self.preserveAspectRatio is not None:
             values.append(
-                "%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserve_aspect_ratio)
+                "%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserveAspectRatio)
             )
         if self.viewbox is not None:
             values.append("%s=%s" % (SVG_ATTR_VIEWBOX, repr(self.viewbox)))
@@ -7757,7 +7758,7 @@ class SVGImage(SVGElement, GraphicObject, Transformable):
         self.url = s.url
         self.data = s.data
         self.viewbox = s.viewbox
-        self.preserve_aspect_ratio = s.preserve_aspect_ratio
+        self.preserveAspectRatio = s.preserveAspectRatio
 
         self.x = s.x
         self.y = s.y
@@ -7780,7 +7781,10 @@ class SVGImage(SVGElement, GraphicObject, Transformable):
         if viewbox is not None:
             self.viewbox = Viewbox(viewbox)
         if SVG_ATTR_PRESERVEASPECTRATIO in values:
-            self.preserve_aspect_ratio = values[SVG_ATTR_PRESERVEASPECTRATIO]
+            if values[SVG_ATTR_PRESERVEASPECTRATIO] == SVG_VALUE_NONE:
+                self.preserveAspectRatio = None
+            else:
+                self.preserveAspectRatio = values[SVG_ATTR_PRESERVEASPECTRATIO]
         self.x = Length(values.get(SVG_ATTR_X, 0)).value()
         self.y = Length(values.get(SVG_ATTR_Y, 0)).value()
         self.width = Length(values.get(SVG_ATTR_WIDTH, "100%")).value()
@@ -7877,7 +7881,7 @@ class SVGImage(SVGElement, GraphicObject, Transformable):
         self.image_height = self.image.height
         self.viewbox = Viewbox(
             "0 0 %d %d" % (self.image_width, self.image_height),
-            self.preserve_aspect_ratio,
+            self.preserveAspectRatio,
         )
         self.render(width=self.image_width, height=self.image_height)
         self.transform = Matrix(self.viewbox_transform) * self.transform

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3057,7 +3057,7 @@ class Viewbox:
             self.y = float(args[1])
             self.width = float(args[2])
             self.height = float(args[3])
-        else:
+        if kwargs:
             self.property_by_values(dict(kwargs))
 
     def __eq__(self, other):

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -7745,10 +7745,6 @@ class SVGImage(SVGElement, GraphicObject, Transformable):
             values.append("%s=%s" % (SVG_ATTR_WIDTH, Length.str(self.width)))
         if self.height != "100%":
             values.append("%s=%s" % (SVG_ATTR_HEIGHT, Length.str(self.height)))
-        if self.image_width != 0:
-            values.append("image_width=%s" % Length.str(self.image_width))
-        if self.image_height != 0:
-            values.append("image_height=%s" % Length.str(self.image_height))
         if self.preserve_aspect_ratio is not None:
             values.append(
                 "%s=%s" % (SVG_ATTR_PRESERVEASPECTRATIO, self.preserve_aspect_ratio)

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3041,7 +3041,7 @@ class Viewbox:
         self.y = y
         self.width = width
         self.height = height
-        if len(args) <= 2:
+        if args and len(args) <= 2:
             viewbox = args[0]
             if isinstance(viewbox, dict):
                 self.property_by_values(viewbox)

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -31,7 +31,7 @@ class TestElementCopy(unittest.TestCase):
         self.assertEqual(matrix, matrix_copy)
 
         # SVG OBJECTS
-        viewbox = Viewbox('0 0 103 109', preserve_aspect_ratio="xMaxyMin slice")
+        viewbox = Viewbox('0 0 103 109', preserveAspectRatio="xMaxyMin slice")
         viewbox_copy = copy(viewbox)
         # self.assertEqual(viewbox, viewbox_copy)
 

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -48,8 +48,8 @@ class TestElementGroup(unittest.TestCase):
         r1 = rects[1]
         self.assertEqual(r1.implicit_x, 0)
         self.assertEqual(r1.implicit_y, 0)
-        self.assertEqual(round(r1.implicit_width,12), 200)
-        self.assertEqual(round(r1.implicit_height,12), 200)
+        self.assertAlmostEqual(r1.implicit_width, 200)
+        self.assertAlmostEqual(r1.implicit_height, 200)
         print(r1.bbox())
 
     def test_issue_107(self):

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -48,8 +48,8 @@ class TestElementGroup(unittest.TestCase):
         r1 = rects[1]
         self.assertEqual(r1.implicit_x, 0)
         self.assertEqual(r1.implicit_y, 0)
-        self.assertEqual(r1.implicit_width, 200)
-        self.assertEqual(r1.implicit_height, 200)
+        self.assertEqual(round(r1.implicit_width,12), 200)
+        self.assertEqual(round(r1.implicit_height,12), 200)
         print(r1.bbox())
 
     def test_issue_107(self):

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -32,8 +32,7 @@ class TestElementsRepr(unittest.TestCase):
         self.assertFalse(obj != eval(repr(obj)))
 
     def test_repr_viewbox(self):
-        obj = Viewbox("0 0 100 60")
-        print(repr(obj))
+        obj = Viewbox("0 0 100 60", "xMid")
         self.assertTrue(obj == eval(repr(obj)))
         self.assertFalse(obj != eval(repr(obj)))
 
@@ -146,4 +145,3 @@ class TestElementsRepr(unittest.TestCase):
         obj = Title(title="SVG Description")
         self.assertTrue(obj == eval(repr(obj)))
         self.assertFalse(obj != eval(repr(obj)))
-

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -297,9 +297,9 @@ class TestElementShape(unittest.TestCase):
         s = SimpleLine(fill='red')
         self.assertEqual(repr(s), "SimpleLine(x1=0.0, y1=0.0, x2=0.0, y2=0.0, fill='#ff0000')")
         s = Polygon(fill='red')
-        self.assertEqual(repr(s), "Polygon(points=(''), fill='#ff0000')")
+        self.assertEqual(repr(s), "Polygon(points='', fill='#ff0000')")
         s = Polyline(fill='red')
-        self.assertEqual(repr(s), "Polyline(points=(''), fill='#ff0000')")
+        self.assertEqual(repr(s), "Polyline(points='', fill='#ff0000')")
         s = Path(fill='red')
         self.assertEqual(repr(s), "Path(fill='#ff0000')")
 

--- a/test/test_viewbox.py
+++ b/test/test_viewbox.py
@@ -6,6 +6,15 @@ from svgelements import *
 
 class TestElementViewbox(unittest.TestCase):
 
+    def test_viewbox_init(self):
+        # Test various ways of creating a viewbox are equal.
+        v1 = Viewbox('0 0 100 100')
+        v2 = Viewbox(x=0, y=0, width=100, height=100)
+        v3 = Viewbox(v1)
+        self.assertEqual(v1, v2)
+        self.assertEqual(v1, v3)
+        self.assertEqual(v2, v3)
+
     def test_viewbox_incomplete_transform(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
                         <svg/>''')

--- a/test/test_viewbox.py
+++ b/test/test_viewbox.py
@@ -6,14 +6,23 @@ from svgelements import *
 
 class TestElementViewbox(unittest.TestCase):
 
-    def test_viewbox_init(self):
+    def test_viewbox_creation(self):
         # Test various ways of creating a viewbox are equal.
-        v1 = Viewbox('0 0 100 100')
-        v2 = Viewbox(x=0, y=0, width=100, height=100)
-        v3 = Viewbox(v1)
+        v1 = Viewbox('0 0 100 100', 'xMid')
+        v2 = Viewbox(viewBox="0 0 100 100", preserve_aspect_ratio="xMid")
+        v3 = Viewbox(x=0, y=0, width=100, height=100, preserveAspectRatio="xMid")
+        v4 = Viewbox(v1)
+        v5 = Viewbox({"x":0, "y":0, "width":100, "height":100, "preserveAspectRatio":"xMid"})
         self.assertEqual(v1, v2)
         self.assertEqual(v1, v3)
+        self.assertEqual(v1, v4)
+        self.assertEqual(v1, v5)
         self.assertEqual(v2, v3)
+        self.assertEqual(v2, v4)
+        self.assertEqual(v2, v5)
+        self.assertEqual(v3, v4)
+        self.assertEqual(v3, v5)
+        self.assertEqual(v4, v5)
 
     def test_viewbox_incomplete_transform(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>


### PR DESCRIPTION
1. Viewbox `init` now handles various forms of arguments so it can recreate from a repr:
    * "x y w h"
    * x=x etc.
2. Viewbox creates a correct better `repr`.
3. SVGImage adds missing attributes, puts the href (which is potentially huge) last and (I hope this is correct) puts the href attribute in quotations so that the end is easily parseable.
4. Various objects parse `preserve_aspect_ratio` as an attribute when the SVG attribute is `preserveAspectRatio` . Backwards compatibility is preserved.