### PR TITLE
Fix move bbox

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.6.8
+version = 1.6.9
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Multimedia :: Graphics
     Topic :: Multimedia :: Graphics :: Editors :: Vector-Based

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -43,7 +43,7 @@ Though not required the Image class acquires new functionality if provided with 
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.6.8"
+SVGELEMENTS_VERSION = "1.6.9"
 
 MIN_DEPTH = 5
 ERROR = 1e-12
@@ -4101,6 +4101,10 @@ class Move(PathSegment):
             return self.end
         else:
             raise IndexError
+
+    def bbox(self):
+        """Return the bounding box for a Move which is the end point."""
+        return self.end.x, self.end.y, self.end.x, self.end.y
 
     def d(self, current_point=None, relative=None, smooth=None):
         if (

--- a/test/test_bbox.py
+++ b/test/test_bbox.py
@@ -219,20 +219,11 @@ class TestElementBbox(unittest.TestCase):
         ))
 
     def test_bbox_subpath(self):
-        values = {
-            'tag': 'rect',
-            'rx': "4",
-            'ry': "2",
-            'x': "50",
-            'y': "51",
-            'width': "20",
-            'height': "10"
-        }
-        p = Path(Rect(values))
-        e = p.subpath(0)
-        self.assertEqual(e.bbox(), (50,51,70,61))
-        e *= "translate(2)"
-        self.assertEqual(e.bbox(), (52, 51, 72, 61))
+        p = Path("M 10,100 H 20 V 80 H 10 Z m 10,-90 H 60 V 70 H 20 Z")
+        e = p.subpath(1)
+        self.assertEqual(e.bbox(), (20, 10, 60, 70))
+        e *= "translate(5)"
+        self.assertEqual(e.bbox(), (25, 10, 65, 70))
 
     def test_bbox_subpath_stroke(self):
         values = {


### PR DESCRIPTION
An incorrect bbox from Move was causing Meerk40t's Cut Inside First to fail when the outside Cut path was a subpath in compound path.  