### PR TITLE
Fix Angle.as_radians

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.6.9
+version = 1.6.10
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -43,7 +43,7 @@ Though not required the Image class acquires new functionality if provided with 
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.6.9"
+SVGELEMENTS_VERSION = "1.6.10"
 
 MIN_DEPTH = 5
 ERROR = 1e-12
@@ -2415,7 +2415,7 @@ class Angle(float):
 
     @property
     def as_radians(self):
-        return self
+        return float(self)
 
     @property
     def as_degrees(self):


### PR DESCRIPTION
Should return a float not an Angle. Other similar properties return a result of a float calculation which is by default float.