### PR TITLE
Add Option for parsing display none in SVG.parse

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.6.16
+version = 1.6.17
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -8552,6 +8552,7 @@ class SVG(Group):
         color="black",
         transform=None,
         context=None,
+        parse_display_none=False,
     ):
         """
         Parses the SVG file. All attributes are things which the SVG document itself could not be aware of, such as
@@ -8565,6 +8566,7 @@ class SVG(Group):
         :param color: the `currentColor` value from outside the current scope.
         :param transform: Any required transformations to be pre-applied to this document
         :param context: Any existing document context.
+        :param parse_display_none: Parse display_none values anyway.
         :return:
         """
         clip = 0
@@ -8588,7 +8590,8 @@ class SVG(Group):
             if event == "start":
                 stack.append((context, values))
                 if (
-                    SVG_ATTR_DISPLAY in values
+                    not parse_display_none
+                    and SVG_ATTR_DISPLAY in values
                     and values[SVG_ATTR_DISPLAY].lower() == SVG_VALUE_NONE
                 ):
                     continue  # Values has a display=none. Do not render anything. No Shadow Dom.

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -4813,10 +4813,10 @@ class Arc(Curve):
                         cy = ab_mid.y
                     else:
                         cx = (
-                                     slope_a * slope_b * (ab_mid.y - bc_mid.y)
-                                     - slope_a * bc_mid.x
-                                     + slope_b * ab_mid.x
-                             ) / (slope_b - slope_a)
+                            slope_a * slope_b * (ab_mid.y - bc_mid.y)
+                            - slope_a * bc_mid.x
+                            + slope_b * ab_mid.x
+                        ) / (slope_b - slope_a)
                         cy = ab_mid.y - (cx - ab_mid.x) / slope_a
                 self.center = Point(cx, cy)
                 cw = bool(Point.orientation(self.start, control, self.end) == 2)
@@ -8847,7 +8847,7 @@ class SVG(Group):
                     context.append(s)
                 elif SVG_TAG_STYLE == tag:
                     textstyle = elem.text
-                    textstyle = re.sub(REGEX_CSS_COMMENT, '', textstyle)
+                    textstyle = re.sub(REGEX_CSS_COMMENT, "", textstyle)
                     assignments = list(re.findall(REGEX_CSS_STYLE, textstyle.strip()))
                     for key, value in assignments:
                         key = key.strip()

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -8687,6 +8687,7 @@ class SVG(Group):
                 values.update(attributes)
                 values[SVG_STRUCT_ATTRIB] = attributes
                 if (
+                    not parse_display_none and
                     SVG_ATTR_DISPLAY in values
                     and values[SVG_ATTR_DISPLAY].lower() == SVG_VALUE_NONE
                 ):

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -43,7 +43,7 @@ Though not required the Image class acquires new functionality if provided with 
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.6.16"
+SVGELEMENTS_VERSION = "1.6.17"
 
 MIN_DEPTH = 5
 ERROR = 1e-12

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -672,9 +672,15 @@ class TestParseDisplay(unittest.TestCase):
                         <line x1="0.0" x2="0.0" y1="0.0" y2="100"/>
                         </g>
                         </svg>''')
+
         m = SVG.parse(q)
-        q = list(m.elements())
-        self.assertFalse(isinstance(q[-1], SimpleLine))
+        e = list(m.elements())
+        self.assertFalse(isinstance(e[-1], SimpleLine))
+
+        q.seek(0)
+        m = SVG.parse(q, parse_display_none=True)
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))
 
     def test_svgfile_display_none_attribute(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
@@ -685,8 +691,13 @@ class TestParseDisplay(unittest.TestCase):
                         </g>
                         </svg>''')
         m = SVG.parse(q)
-        q = list(m.elements())
-        self.assertFalse(isinstance(q[-1], SimpleLine))
+        e = list(m.elements())
+        self.assertFalse(isinstance(e[-1], SimpleLine))
+
+        q.seek(0)
+        m = SVG.parse(q, parse_display_none=True)
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))
 
     def test_svgfile_display_mixed(self):
         """
@@ -700,9 +711,13 @@ class TestParseDisplay(unittest.TestCase):
                         </g>
                         </svg>''')
         m = SVG.parse(q)
-        q = list(m.elements())
-        print(q)
-        self.assertFalse(isinstance(q[-1], SimpleLine))
+        e = list(m.elements())
+        self.assertFalse(isinstance(e[-1], SimpleLine))
+
+        q.seek(0)
+        m = SVG.parse(q, parse_display_none=True)
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))
 
     def test_svgfile_display_none_class(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
@@ -717,8 +732,13 @@ class TestParseDisplay(unittest.TestCase):
                         </g>
                         </svg>''')
         m = SVG.parse(q)
-        q = list(m.elements())
-        self.assertFalse(isinstance(q[-1], SimpleLine))
+        e = list(m.elements())
+        self.assertFalse(isinstance(e[-1], SimpleLine))
+
+        q.seek(0)
+        m = SVG.parse(q, parse_display_none=True)
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))
 
     def test_svgfile_display_None_class(self):
         """
@@ -736,9 +756,13 @@ class TestParseDisplay(unittest.TestCase):
                         </g>
                         </svg>''')
         m = SVG.parse(q)
-        q = list(m.elements())
-        self.assertFalse(isinstance(q[-1], SimpleLine))
+        e = list(m.elements())
+        self.assertFalse(isinstance(e[-1], SimpleLine))
 
+        q.seek(0)
+        m = SVG.parse(q, parse_display_none=True)
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))
 
     def test_svgfile_visibility_hidden(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
@@ -749,8 +773,13 @@ class TestParseDisplay(unittest.TestCase):
                         </g>
                         </svg>''')
         m = SVG.parse(q)
-        q = list(m.elements())
-        self.assertTrue(isinstance(q[-1], SimpleLine))  # Hidden elements still exist.
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))  # Hidden elements still exist.
+
+        q.seek(0)
+        m = SVG.parse(q, parse_display_none=True)
+        e = list(m.elements())
+        self.assertTrue(isinstance(e[-1], SimpleLine))  # forcing none does not affect
 
 
 class TestParseDefUse(unittest.TestCase):


### PR DESCRIPTION
* Adds an option for SVG.parse to parse_display_none values. The typical rule for svgelements is that elements are given for any rendered objects, however, we do not `display:none` values because those are not rendered. If we set the option we will parse those objects *anyway*.