### PR TITLE
`npoint()` zero length fallback

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.7.4
+version = 1.7.5
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -43,7 +43,7 @@ Though not required the Image class acquires new functionality if provided with 
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.7.4"
+SVGELEMENTS_VERSION = "1.7.5"
 
 MIN_DEPTH = 5
 ERROR = 1e-12

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3667,9 +3667,12 @@ class Shape(SVGElement, GraphicObject, Transformable):
             self._calc_lengths(error=error, segments=segments)
         xy = np.empty((len(positions), 2), dtype=float)
         if self._length == 0:
-            i = int(round(positions * (len(segments) - 1)))
-            point = segments[i].point(0.0)
-            xy[:] = point
+            # all segments have 0 length
+            seg_points = np.empty((len(segments), 2), dtype=float)
+            for i, seg in enumerate(segments):
+                seg_points[i] = seg.point(0)
+            indexes = np.round(positions * (len(segments) - 1)).astype(int)
+            xy[:] = seg_points[indexes]
             return xy
 
         # Find which segment the point we search for is located on:

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -605,6 +605,29 @@ class TestElementShape(unittest.TestCase):
             for p, p1, p2 in zip(pos, v1, v2):
                 self.assertEqual(Point(p1), Point(p2))
 
+    def test_shape_npoints_len0(self):
+        """
+        If the length of a shape is 0 the npoint code calls 0-length fallback which used an illegal round command
+        """
+        import numpy as np
+        shapes = [
+            Rect(0, 0, 0, 0),
+            Circle(0, 0, 0),
+            Ellipse(0, 0, 0, 0),
+            Polygon(points=((0, 0), (0, 0), (0, 0))),
+            Polyline(points=((0, 0), (0, 0), (0, 0), (0, 0))),
+        ]
+
+        for shape in shapes:
+            pos = np.linspace(0, 1, 1000)
+            v1 = shape.npoint(pos)
+            if v1 is None:
+                continue  # Degenerate shape had no segments
+            v2 = [shape.point(p) for p in pos]
+
+            for p, p1, p2 in zip(pos, v1, v2):
+                self.assertEqual(Point(p1), Point(p2))
+
 
 def reification_checks(test, shape):
     correct_reify(test, shape * "rotate(-90) translate(20,0)")

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -616,6 +616,7 @@ class TestElementShape(unittest.TestCase):
             Ellipse(0, 0, 0, 0),
             Polygon(points=((0, 0), (0, 0), (0, 0))),
             Polyline(points=((0, 0), (0, 0), (0, 0), (0, 0))),
+            Path("M0,0zM1,1z")
         ]
 
         for shape in shapes:

--- a/test/test_shape.py
+++ b/test/test_shape.py
@@ -599,13 +599,10 @@ class TestElementShape(unittest.TestCase):
 
         for shape in shapes:
             pos = np.linspace(0, 1, 1000)
-            pts1 = shape.npoint(pos)  # Test rendered worthless.
-            v2 = []
-            for i in range(len(pos)):
-                v2.append(shape.point(pos[i]))
+            v1 = shape.npoint(pos)
+            v2 = [shape.point(p) for p in pos]
 
-            for p, p1, p2 in zip(pos, pts1, v2):
-                self.assertEqual(shape.point(p), Point(p1))
+            for p, p1, p2 in zip(pos, v1, v2):
                 self.assertEqual(Point(p1), Point(p2))
 
 


### PR DESCRIPTION
Correct edge case fallback where entire shape and all segments within it are zero length for the numpy `npoint` code. 