### PR TITLE
Correct (optionally) Issue #217

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -8902,6 +8902,7 @@ class SVG(Group):
         transform=None,
         context=None,
         parse_display_none=False,
+        on_error="ignore"
     ):
         """
         Parses the SVG file. All attributes are things which the SVG document itself could not be aware of, such as
@@ -8916,6 +8917,7 @@ class SVG(Group):
         :param transform: Any required transformations to be pre-applied to this document
         :param context: Any existing document context.
         :param parse_display_none: Parse display_none values anyway.
+        :param on_error: Error mode, "ignore", "raise", "stop"
         :return:
         """
         use = 0
@@ -9129,9 +9131,13 @@ class SVG(Group):
                     SVG_TAG_RECT,
                     SVG_TAG_IMAGE,
                 ):
+                    parse_error = None
+                    s = None
                     try:
                         if SVG_TAG_PATH == tag:
-                            s = Path(values)
+                            # Delayed path parsing, for partial paths.
+                            s = Path(values, pathd_loaded=True)
+                            s.parse(values.get(SVG_ATTR_DATA))
                         elif SVG_TAG_CIRCLE == tag:
                             s = Circle(values)
                         elif SVG_TAG_ELLIPSE == tag:
@@ -9146,8 +9152,11 @@ class SVG(Group):
                             s = Rect(values)
                         else:  # SVG_TAG_IMAGE == tag:
                             s = Image(values)
-                    except ValueError:
-                        continue
+                    except ValueError as e:
+                        parse_error = e
+                        if s is None:
+                            # s was not established we continue without it.
+                            continue
                     s.render(ppi=ppi, width=width, height=height)
                     if reify:
                         s.reify()
@@ -9155,6 +9164,14 @@ class SVG(Group):
                         continue
                     if context is not None:
                         context.append(s)
+                    if parse_error:
+                        # Error was encountered, but s was established and processed.
+                        if on_error == "ignore":
+                            continue
+                        elif on_error == "raise":
+                            raise parse_error
+                        else:  # "stop"
+                            return root
                 elif tag in (
                     SVG_TAG_STYLE,
                     SVG_TAG_TEXT,

--- a/test/test_parsing.py
+++ b/test/test_parsing.py
@@ -936,3 +936,38 @@ class TestParseDefUse(unittest.TestCase):
         line = list(m.elements(conditional=lambda el: isinstance(el, Text)))[0]
         self.assertIsInstance(line, Text)
         self.assertEqual(line.font_weight, "bolder")
+
+    def test_parse_error_issue_217_stop(self):
+        block = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" 
+                        xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <path d="M10,10 L20,20 L NaN NaN"/>
+                        <path d="M20,10 L20,20"/>
+                        </svg>''')
+
+        m = SVG.parse(block, on_error="stop")
+        q = list(m.elements())
+        self.assertEqual(2, len(q))
+        self.assertTrue(isinstance(q[-1], Path))
+        self.assertEquals("M 10,10 L 20,20", q[-1].d())
+
+    def test_parse_error_issue_217_raises(self):
+        block = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" 
+                                xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <path d="M10,10 L20,20 L NaN NaN"/>
+                                <path d="M20,10 L20,20"/>
+                                </svg>''')
+        self.assertRaises(ValueError, lambda: SVG.parse(block, on_error="raise"))
+
+    def test_parse_error_issue_217_ignore(self):
+        block = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" 
+                                xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xlink="http://www.w3.org/1999/xlink">
+                                <path d="M10,10 L20,20 L NaN NaN"/>
+                                <path d="M20,10 L20,20"/>
+                                </svg>''')
+
+        m = SVG.parse(block)
+        q = list(m.elements())
+        self.assertEqual(3, len(q))


### PR DESCRIPTION
See #217 

It has been brought to my attention that svgelements violates error handling section 9.5.4 of the SVG spec. That when a malformed svg path is sent the SVG should still parse up to the point of the error and return that faulty path. However, due to using a `parse` function unattached to objects the ability to return an error and the object is severely hampered. If you, however, declared a Path() then called path.parse(), an error could be thrown while still modifying the current path. This could be done to produce partial paths.

Furthermore, without this same mechanism in the SVG class directly, we hit the same issue of not returning both the error and the object. So if we introduce an `on_error` mechanism to the `parse()` function we can choose the operation. We currently 'ignore' errors that are found within the parsing. However, we could equally raise those error directly for the end-user, or stop parsing when we reach an error while parsing.

This does not, however, provide both the error and the parsed value. To do that we'd need to already have an SVG object and be running a parse function on that svg object (we currently run staticmethod parse() which is on the SVG class itself). At this point is is not clear we can easily do both. We can also, sometimes, due to bad svg files have a `group` as the outermost object and so `parse()` will return a group. This behavior would be impossible if we already constructed the SVG and parsed the class as a secondary operation.

https://www.w3.org/TR/SVG2/paths.html#PathDataErrorHandling