### PR TITLE
1.9.2 Version Bump, Support version update.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = svgelements
-version = 1.9.1
+version = 1.9.2
 description = Svg Elements Parsing
 long_description_content_type=text/markdown
 long_description = file: README.md
@@ -10,14 +10,12 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
-    Programming Language :: Python :: Implementation :: PyPy
+    Programming Language :: Python :: 3.11
     Topic :: Multimedia :: Graphics
     Topic :: Multimedia :: Graphics :: Editors :: Vector-Based
     Topic :: Software Development :: Libraries :: Python Modules

--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -43,7 +43,7 @@ Though not required the Image class acquires new functionality if provided with 
 and the Arc can do exact arc calculations if scipy is installed.
 """
 
-SVGELEMENTS_VERSION = "1.9.1"
+SVGELEMENTS_VERSION = "1.9.2"
 
 MIN_DEPTH = 5
 ERROR = 1e-12


### PR DESCRIPTION
Fixes ##219

Drop support for 3.5. The 1.9+ feature of saving for polylines requires fstrings which are 3.6