### PR TITLE
Issue 227, Write xml with pathlib objects (rather than only filename:str)

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -3428,8 +3428,8 @@ class SVGElement(object):
         self.values[key] = value
         return self
 
-    def write_xml(self, f):
-        write(self, f)
+    def write_xml(self, f, **kwargs):
+        write(self, f, **kwargs)
 
     def string_xml(self):
         return tostring(self)
@@ -9355,18 +9355,26 @@ def tostring(node):
     return tostring(_write_node(node), encoding="unicode")
 
 
-def write(node, f, pretty=True):
+def write(node, f, pretty=True, **kwargs):
+    """
+    Gets the write node and writes to the ElementTree.write() function, all options in Element.write() are passed
+    along via this method. encoding, xml_declaration, short_empty_elements, etc.
+    """
     from xml.etree.ElementTree import ElementTree
 
     root = _write_node(node)
     if pretty:
         _pretty_print(root)
     tree = ElementTree(root)
-    if f.lower().endswith("svgz"):
-        import gzip
+    try:
+        if f.lower().endswith("svgz"):
+            import gzip
 
-        f = gzip.open(f, "wb")
-    tree.write(f)
+            f = gzip.open(f, "wb")
+    except AttributeError:
+        # might be a pathlib.Path()
+        pass
+    tree.write(f, **kwargs)
 
 
 def _write_node(node, xml_tree=None, viewport_transform=None):

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -99,6 +99,32 @@ class TestElementWrite(unittest.TestCase):
         svg.append(Rect("10%", "10%", "80%", "80%", fill="red"))
         svg.write_xml(file, pretty=False, short_empty_elements=False)
 
+    def test_write_filename(self):
+        """
+        Tests filename file saving. This is permitted by the xml writer but would crash see issue #227
+
+        This also provides an example short_empty_elements off, utf-8 encoding.
+
+        """
+        file1 = "myfile-f.svg"
+        self.addCleanup(os.remove, file1)
+        svg = SVG(viewport="0 0 1000 1000", height="10mm", width="10mm")
+        svg.append(Rect("10%", "10%", "80%", "80%", fill="red"))
+        svg.write_xml(file1, short_empty_elements=False, encoding="utf-8")
+
+    def test_write_filename_svgz(self):
+        """
+        Tests pathlib.Path file saving. This is permitted by the xml writer but would crash see issue #227
+
+        This also provides an example of xml_declaration=True.
+
+        """
+        file1 = "myfile-f.svgz"
+        self.addCleanup(os.remove, file1)
+        svg = SVG(viewport="0 0 1000 1000", height="10mm", width="10mm")
+        svg.append(Rect("10%", "10%", "80%", "80%", fill="red"))
+        svg.write_xml(file1, xml_declaration=True)
+
 
     # def test_read_write(self):
     #     import glob

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -1,4 +1,6 @@
 import io
+import os
+import pathlib
 import unittest
 from xml.etree.ElementTree import ParseError
 
@@ -82,6 +84,20 @@ class TestElementWrite(unittest.TestCase):
         c = SimpleLine(x1=0, x2=10, y1=5, y2=6, id="line", fill="light grey")
         q = SVG.parse(io.StringIO(c.string_xml()))
         self.assertEqual(c, q)
+
+    def test_write_pathlib_issue_227(self):
+        """
+        Tests pathlib.Path file saving. This is permitted by the xml writer but would crash see issue #227
+
+        This also provides an example of pretty-print off and short_empty_elements off (an xml writer option).
+
+        """
+        file1 = "myfile.svg"
+        self.addCleanup(os.remove, file1)
+        file = pathlib.Path(file1)
+        svg = SVG(viewport="0 0 1000 1000", height="10mm", width="10mm")
+        svg.append(Rect("10%", "10%", "80%", "80%", fill="red"))
+        svg.write_xml(file, pretty=False, short_empty_elements=False)
 
 
     # def test_read_write(self):


### PR DESCRIPTION
* passes arguments to write along to the ElementTree.write() for weird edge cases.
* allows use of pathlib.Path() objects for saving.
* Add test to confirm