### PR TITLE
Fix tests by fixing typos

### DIFF
--- a/test/test_cubic_bezier.py
+++ b/test/test_cubic_bezier.py
@@ -79,4 +79,4 @@ class TestElementCubicBezierPoint(unittest.TestCase):
         p = Path(transform=Matrix(682.657124793113, 0.000000000003, -0.000000000003, 682.657124793113, 257913.248909660178, -507946.354527872754))
         p += CubicBezier(start=Point(-117.139521365,1480.99923469), control1=Point(-41.342266634,1505.62725567), control2=Point(40.3422666342,1505.62725567), end=Point(116.139521365,1480.99923469))
         bounds = p.bbox()
-        self.assertNotAlmostEquals(bounds[1], bounds[3], delta=100)
+        self.assertNotAlmostEqual(bounds[1], bounds[3], delta=100)

--- a/test/test_write.py
+++ b/test/test_write.py
@@ -24,7 +24,7 @@ class TestElementWrite(unittest.TestCase):
 
     def test_write_group(self):
         g = Group()
-        self.assertEquals(g.string_xml(), "<g />")
+        self.assertEqual(g.string_xml(), "<g />")
 
     def test_write_rect(self):
         r = Rect("1in", "1in", "3in", "3in", rx="5%")


### PR DESCRIPTION
typos in assertEqual(s) caused tests to fail