### PR TITLE
Add support for Inkscape arc shapes

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -9233,7 +9233,7 @@ class SVG(Group):
                         if SVG_TAG_PATH == tag:
                             # Delayed path parsing, for partial paths.
                             s = Path(values, pathd_loaded=True)
-                            s.parse(values.get(SVG_ATTR_DATA))
+                            s.parse(values.get(SVG_ATTR_DATA, ""))
                         elif SVG_TAG_CIRCLE == tag:
                             s = Circle(values)
                         elif SVG_TAG_ELLIPSE == tag:


### PR DESCRIPTION
This PR adds support for Inkscape's not-quite-a-circle shapes. They're derived from the _RoundShape class and extend them by allowing a start and stop angle, with different options for closing the open path.

I'm sure I'm missing some details in my PR, like specific code formatting or more docstrings/comments. Please let me know what you'd like changed and I'll be happy to make the updates.

Also let me know if you think this is beyond the scope of svgelements. This PR solves a problem for me and I'll happily contribute back but I also understand if you'd like to stick to plain SVG. That said, there are other Inkscape shapes like stars and spirals that might be fun to add as well :)