### PR TITLE
Expose write_node

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -9658,6 +9658,9 @@ def _write_node(node, xml_tree=None, viewport_transform=None):
 
     return xml_tree
 
+def write_node(node, xml_tree=None, viewport_transform=None):
+    # Wrapper function to expose the internal underscore function
+    _write_node(node, xml_tree, viewport_transform)
 
 def _pretty_print(current, parent=None, index=-1, depth=0):
     for i, node in enumerate(current):


### PR DESCRIPTION
Expose the internal _write_node function to the outer world. Picks up feature request #256

## Summary by Sourcery

New Features:
- Expose the internal _write_node function through a new public write_node function.