### PR TITLE
incorect dimensions with only one of `width` or `height`?

### DIFF
--- a/svgelements/svgelements.py
+++ b/svgelements/svgelements.py
@@ -9146,6 +9146,20 @@ class SVG(Group):
                     # explicit transform, parent transforms, attribute transforms, viewport transforms
                     s = SVG(values)
 
+                    # if we have only one of `s.width` and `s.height` we can deduce the other one
+                    # assuming we have a viewbox.
+                    if s.viewbox is not None:
+                        has_absolute_width = isinstance(s.width, float) or (
+                            isinstance(s.width, Length) and s.width.units != "%"
+                        )
+                        has_absolute_height = isinstance(s.height, float) or (
+                            isinstance(s.height, Length) and s.height.units != "%"
+                        )
+                        if width is None and has_absolute_width and not has_absolute_height:
+                            s.height = s.width * s.viewbox.height / s.viewbox.width
+                        elif height is None and not has_absolute_width and has_absolute_height:
+                            s.width = s.height * s.viewbox.width / s.viewbox.height
+
                     if width is None:
                         # If a dim was not provided but a viewbox was, use the viewbox dim as physical size, else 1000
                         width = (

--- a/test/test_viewbox.py
+++ b/test/test_viewbox.py
@@ -149,6 +149,13 @@ class TestElementViewbox(unittest.TestCase):
         self.assertEqual(m.width, 4.8 * 100)
         self.assertEqual(m.height, 4.8 * 200)
 
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0, 0, 100, 200" height="100%"/>''')
+        m = SVG.parse(q)
+        self.assertEqual(Matrix(m.viewbox_transform), 'scale(1)')
+        self.assertEqual(m.width, 100)
+        self.assertEqual(m.height, 200)
+
     def test_viewbox_incomplete_width_viewbox_default_dimensions(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
                         <svg viewBox="0, 0, 100, 200" width="400"/>''')
@@ -163,6 +170,13 @@ class TestElementViewbox(unittest.TestCase):
         self.assertEqual(Matrix(m.viewbox_transform), 'scale(9.6)')
         self.assertEqual(m.width, 9.6 * 100)
         self.assertEqual(m.height, 9.6 * 200)
+
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0, 0, 100, 200" width="100%"/>''')
+        m = SVG.parse(q)
+        self.assertEqual(Matrix(m.viewbox_transform), 'scale(1)')
+        self.assertEqual(m.width, 100)
+        self.assertEqual(m.height, 200)
 
     def test_viewbox_aspect_ratio_xMinMax(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>

--- a/test/test_viewbox.py
+++ b/test/test_viewbox.py
@@ -134,6 +134,36 @@ class TestElementViewbox(unittest.TestCase):
         self.assertEqual(m.width, 200)
         self.assertEqual(m.height, 200)
 
+    def test_viewbox_incomplete_height_viewbox_default_dimensions(self):
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0, 0, 100, 200" height="400"/>''')
+        m = SVG.parse(q)
+        self.assertEqual(Matrix(m.viewbox_transform), 'scale(2)')
+        self.assertEqual(m.width, 2 * 100)
+        self.assertEqual(m.height, 2 * 200)
+
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0, 0, 100, 200" height="10in"/>''')
+        m = SVG.parse(q)
+        self.assertEqual(Matrix(m.viewbox_transform), 'scale(4.8)')
+        self.assertEqual(m.width, 4.8 * 100)
+        self.assertEqual(m.height, 4.8 * 200)
+
+    def test_viewbox_incomplete_width_viewbox_default_dimensions(self):
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0, 0, 100, 200" width="400"/>''')
+        m = SVG.parse(q)
+        self.assertEqual(Matrix(m.viewbox_transform), 'scale(4)')
+        self.assertEqual(m.width, 4 * 100)
+        self.assertEqual(m.height, 4 * 200)
+
+        q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
+                        <svg viewBox="0, 0, 100, 200" width="10in"/>''')
+        m = SVG.parse(q)
+        self.assertEqual(Matrix(m.viewbox_transform), 'scale(9.6)')
+        self.assertEqual(m.width, 9.6 * 100)
+        self.assertEqual(m.height, 9.6 * 200)
+
     def test_viewbox_aspect_ratio_xMinMax(self):
         q = io.StringIO(u'''<?xml version="1.0" encoding="utf-8" ?>
                         <svg preserveAspectRatio="xMid" viewBox="0 0 100 100" height="100" width="300"/>''')


### PR DESCRIPTION
When parsing an SVG with a `viewBox` but only one of `width` or `height` (without passing dimensions to `SVG.parse()`)
the `.width` and `.heigth` of the resulting `SVG` look incorrect:
```xml
<svg viewBox="0 0 4 3" width="40"/> <!-- .width = 40.0 .height = 3.0 -->
<svg viewBox="0 0 4 3" height="30"/> <!-- .width = 4.0 .height = 30.0 -->
<svg viewBox="0 0 4 3" width="4in"/> <!-- .width = 384.0 .height = 3.0 -->
<svg viewBox="0 0 4 3" height="3in"/> <!-- .width = 4.0 .height = 288.0 -->
```

Shouldn't we be able to use the aspect ratio of the viewbox to deduce the missing dimension?

With this PR we get:
```xml
<svg viewBox="0 0 4 3" width="40"/> <!-- .width = 40.0 .height = 30.0 -->
<svg viewBox="0 0 4 3" height="30"/> <!-- .width = 40.0 .height = 30.0 -->
<svg viewBox="0 0 4 3" width="4in"/> <!-- .width = 384.0 .height = 288.0 -->
<svg viewBox="0 0 4 3" height="3in"/> <!-- .width = 384.0 .height = 288.0 -->
```

Could anyone please confirm:
1. whether my assumption is correct
2. how sound the implementation is as I'm not familiar with the intricacies of the parsing/rendering code


<details>
<summary>Sample code</summary>

```py
from io import StringIO
import svgelements


def test(svg_src: str):
    parsed = svgelements.SVG.parse(StringIO(svg_src))
    print(f"{svg_src} <!-- .width = {parsed.width} .height = {parsed.height} -->")


test('<svg viewBox="0 0 4 3" width="40"/>')
test('<svg viewBox="0 0 4 3" height="30"/>')
test('<svg viewBox="0 0 4 3" width="4in"/>')
test('<svg viewBox="0 0 4 3" height="3in"/>')
```
</details>

## Summary by Sourcery

Improves SVG parsing by inferring missing dimensions from the `viewBox` attribute. When an SVG defines a `viewBox` and either `width` or `height`, the missing dimension is calculated based on the `viewBox`'s aspect ratio. Includes new tests to validate the fix.

Bug Fixes:
- Fixes an issue where the height or width of an SVG was not correctly inferred from the `viewBox` when only one dimension was specified.

Enhancements:
- Infers the missing dimension of an SVG from the `viewBox` aspect ratio when only one of `width` or `height` is provided.

Tests:
- Adds new tests to verify that the width and height of an SVG are correctly inferred from the `viewBox` when only one dimension is specified.